### PR TITLE
Better state network state switching

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,13 @@
 import { FormControl, Button, TextField, Divider, View, Card } from "reshaped";
 import { useFormik } from "formik";
 import { isAddress } from "viem";
-import { useNavigate } from "react-router-dom";
-import { useContext } from "react";
-import { CurrentNetwork } from "./Root";
+import { useNavigate, useOutletContext } from "react-router-dom";
+import { NetworkContext } from "../components/Contexts";
 
 function FormAddressInput() {
   const navigate = useNavigate();
 
-  const network = useContext(CurrentNetwork);
+  const { currentNetwork: network } = useOutletContext<NetworkContext>();
 
   const formik = useFormik({
     initialValues: {
@@ -53,6 +52,8 @@ function FormAddressInput() {
 export function App() {
   const navigate = useNavigate();
 
+  const chainId = useOutletContext<NetworkContext>().currentNetwork;
+
   return (
     <View padding={10} justify="space-between" gap={6} direction="column">
       <Card>
@@ -64,7 +65,7 @@ export function App() {
           <Button
             onClick={(evt) => {
               evt.preventDefault();
-              navigate("/create");
+              navigate(`/safe/${chainId}/create`);
             }}
           >
             Create a New Safe

--- a/src/app/CreateSafe.tsx
+++ b/src/app/CreateSafe.tsx
@@ -1,14 +1,14 @@
-import { useCallback, useContext, useEffect, useState } from "react";
-import { CurrentNetwork, WalletProviderContext } from "./Root";
+import { useCallback, useEffect, useState } from "react";
 import { Field, FieldArray, Formik } from "formik";
 import { Text, Button, FormControl, TextField, View, useToast } from "reshaped";
 import { allowedNetworks, contractNetworks } from "../chains";
 import { isAddress } from "viem";
 import { ethers } from "ethers";
 import { EthersAdapter, SafeFactory } from "@safe-global/protocol-kit";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import { AbstractSigner } from "ethers";
 import { BrowserProvider } from "ethers";
+import { NetworkContext } from "../components/Contexts";
 
 function validateAddress(value: string) {
   if (!isAddress(value)) {
@@ -30,8 +30,8 @@ function validateSafeArguments(values: any) {
 }
 
 export function CreateSafe() {
-  const provider = useContext(WalletProviderContext);
-  const network = useContext(CurrentNetwork);
+  const { walletProvider: provider } = useOutletContext<NetworkContext>();
+  const { currentNetwork: network } = useOutletContext<NetworkContext>();
   const toaster = useToast();
   const navigate = useNavigate();
   const [signerInfo, setSignerInfo] = useState<
@@ -51,7 +51,7 @@ export function CreateSafe() {
     if (provider) {
       updateSignerInfo(provider);
     }
-  }, [provider]);
+  }, [provider, updateSignerInfo]);
 
   const submitCallback = useCallback(
     async (data: any) => {
@@ -86,7 +86,7 @@ export function CreateSafe() {
         });
       }
     },
-    [provider, signerInfo],
+    [navigate, network, signerInfo, toaster]
   );
 
   return (

--- a/src/app/NewSafeProposal.tsx
+++ b/src/app/NewSafeProposal.tsx
@@ -1,22 +1,14 @@
 import { Field, FieldArray, Formik } from "formik";
 import { SafeInformation } from "../components/SafeInformation";
 import { Card, View, Text, Button, useToast } from "reshaped";
-import {
-  SyntheticEvent,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { SyntheticEvent, useCallback, useEffect, useState } from "react";
 import { Address, Hex, formatEther } from "viem";
 import { validateAddress, validateETH } from "../utils/validators";
 import { GenericField } from "../components/GenericField";
 import { DataActionPreview } from "../components/DataActionPreview";
 import Safe, { EthersAdapter } from "@safe-global/protocol-kit";
-import { WalletProviderContext } from "./Root";
 import { ethers } from "ethers";
 import { contractNetworks } from "../chains";
-import { SafeInformationContext } from "./ViewSafe";
 import {
   DEFAULT_ACTION_ITEM,
   DEFAULT_PROPOSAL,
@@ -30,6 +22,8 @@ import {
   transformValuesToWei,
 } from "../utils/etherFormatting";
 import { BrowserProvider } from "ethers";
+import { useOutletContext } from "react-router-dom";
+import { NetworkContext, SafeContext } from "../components/Contexts";
 
 const FormActionItem = ({
   name,
@@ -140,36 +134,11 @@ const signAndExecuteTx = async ({
   return executedTxn;
 };
 
-const useSafe = ({
-  provider,
-  safeAddress,
-}: {
-  provider: BrowserProvider | null;
-  safeAddress: Address | undefined;
-}) => {
-  const [safe, setSafe] = useState<Safe>();
-
-  useEffect(() => {
-    if (!provider || !safeAddress) {
-      return;
-    }
-
-    const loadSafe = async () => {
-      const adapter = await createSafeAdapter({ provider, safeAddress });
-      setSafe(adapter);
-    };
-
-    loadSafe();
-  }, [provider, safeAddress]);
-
-  return safe;
-};
-
 const useGetSafeTxApprovals = ({ proposal }: { proposal: Proposal }) => {
-  const safeInformation = useContext(SafeInformationContext);
+  const { safeInformation } = useOutletContext<SafeContext>();
 
-  const safeSdk = safeInformation?.safeSdk;
-  const safeSdk2 = safeInformation?.safeSdk2;
+  const safeSdk = safeInformation.safeSdk;
+  const safeSdk2 = safeInformation.safeSdk2;
 
   const [approvers, setApprovers] = useState<Address[]>([]);
 
@@ -196,7 +165,7 @@ const useGetSafeTxApprovals = ({ proposal }: { proposal: Proposal }) => {
 };
 
 const useAccountAddress = () => {
-  const walletProvider = useContext(WalletProviderContext);
+  const { walletProvider } = useOutletContext<NetworkContext>();
 
   const [address, setAddress] = useState<Address>();
 
@@ -244,12 +213,8 @@ const ViewProposal = ({
   proposal: Proposal;
   handleEditClicked: (evt: SyntheticEvent) => void;
 }) => {
-  const safeInformation = useContext(SafeInformationContext);
-  const walletProvider = useContext(WalletProviderContext);
-  const safe = useSafe({
-    provider: walletProvider,
-    safeAddress: safeInformation?.address,
-  });
+  const { safeInformation } = useOutletContext<SafeContext>();
+  const safe = safeInformation.safeSdk;
 
   const toaster = useToast();
 
@@ -380,7 +345,7 @@ const EditProposal = ({
       }
       setIsEditing(false);
     },
-    [setIsEditing, setProposal],
+    [proposal, setIsEditing, setProposal, setProposalParams]
   );
 
   const defaultActions = proposal || DEFAULT_PROPOSAL;

--- a/src/app/SafeInformationPage.tsx
+++ b/src/app/SafeInformationPage.tsx
@@ -1,6 +1,6 @@
 import { Button, View } from "reshaped";
 import { SafeInformation } from "../components/SafeInformation";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 export const SafeInformationPage = () => {
   const { networkId, safeAddress } = useParams();

--- a/src/app/Wrapper.tsx
+++ b/src/app/Wrapper.tsx
@@ -14,12 +14,12 @@ const router = createHashRouter([
     Component: Root,
     children: [
       {
-        path: "/",
+        path: "/safe/:networkId",
         index: true,
         Component: App,
       },
       {
-        path: "/create",
+        path: "/safe/:networkId/create",
         Component: CreateSafe,
       },
       {

--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -1,6 +1,6 @@
-import { useContext } from "react";
-import { CurrentNetwork } from "../app/Root";
 import { goerli, mainnet, optimism, zora, zoraTestnet } from "viem/chains";
+import { useOutletContext } from "react-router-dom";
+import { NetworkContext } from "./Contexts";
 
 export const networkToExplorer = {
   [mainnet.id]: "https://etherscan.io/",
@@ -17,7 +17,7 @@ export const AddressView = ({
   address: `0x${string}`;
   prettyName?: string;
 }) => {
-  const currentNetwork = useContext(CurrentNetwork);
+  const currentNetwork = useOutletContext<NetworkContext>().currentNetwork;
   //   const { data: ensName } = useEns({ address, enabled: !prettyName });
   const ensName = null;
 

--- a/src/components/Contexts.ts
+++ b/src/components/Contexts.ts
@@ -1,0 +1,23 @@
+import Safe from "@safe-global/protocol-kit";
+import { BrowserProvider } from "ethers";
+import { Address } from "viem";
+
+export type SafeInformationType = {
+  owners: string[];
+  threshold: number;
+  chainId: number;
+  nonce: number;
+  address: Address;
+  safeSdk: Safe;
+  safeSdk2: Safe;
+};
+
+export interface NetworkContext {
+  walletProvider: BrowserProvider;
+  currentNetwork: number;
+  
+}
+
+export interface SafeContext {
+  safeInformation: SafeInformationType;
+}

--- a/src/components/DataActionPreview.tsx
+++ b/src/components/DataActionPreview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Address, Hex } from "viem";
 import {
   base,
@@ -9,7 +9,8 @@ import {
   zora,
   zoraTestnet,
 } from "viem/chains";
-import { CurrentNetwork } from "../app/Root";
+import { useOutletContext } from "react-router-dom";
+import { NetworkContext } from "./Contexts";
 
 const networkToEtherActor: any = {
   [mainnet.id]: "mainnet",
@@ -22,7 +23,7 @@ const networkToEtherActor: any = {
 };
 
 export const DataActionPreview = ({ to, data }: { to: Address; data: Hex }) => {
-  const currentNetwork = useContext(CurrentNetwork);
+  const currentNetwork = useOutletContext<NetworkContext>().currentNetwork;
   const [responseData, setResponseData] = useState<any>();
 
   const fetchData = useCallback(async () => {

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -1,52 +1,37 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { useCallback, useEffect } from "react";
+import { useCallback, useState } from "react";
 import { FormControl, Select } from "reshaped";
 import { allowedNetworks } from "../chains";
-import { BrowserProvider } from "ethers";
+import { useNavigate } from "react-router-dom";
 
 export const NetworkSwitcher = ({
   currentNetwork,
-  setCurrentNetwork,
-  provider,
 }: {
-  currentNetwork: number;
-  setCurrentNetwork: (chainId: number) => void;
-  provider: BrowserProvider | undefined;
+  currentNetwork: string | undefined;
 }) => {
+  const [currentNetworkValue, setCurrentNetworkValue] = useState(currentNetwork);
+  const navigate = useNavigate();
   const changeNetwork = useCallback(
-    ({ value }: { value: string }) => {
-      provider?.send("wallet_switchEthereumChain", [
-        {
-          chainId: `0x${parseInt(value).toString(16)}`,
-        },
-      ]);
+    (e: { value: string }) => {
+      const networkId = e.value; 
+      setCurrentNetworkValue(networkId);
+
+      navigate(`/safe/${networkId}`);
     },
-    [provider],
+    [navigate]
   );
-
-  useEffect(() => {
-    const handleChainChanged = (chainId: unknown) => {
-      setCurrentNetwork(parseInt(chainId as string));
-    };
-    // @ts-ignore
-    window.ethereum?.on("chainChanged", handleChainChanged);
-
-    return () => {
-      // @ts-ignore
-      window.ethereum?.removeListener("chainChanged", handleChainChanged);
-    };
-  });
 
   return (
     <FormControl>
       <FormControl.Label>Network:</FormControl.Label>
       <Select
         name="network"
-        value={currentNetwork.toString()}
+        value={currentNetworkValue}
         onChange={changeNetwork}
         options={Object.values(allowedNetworks)
           .filter((d) => !!d)
           .map((allowedNetwork) => ({
+            key: allowedNetwork.id.toString(),
             value: allowedNetwork.id.toString(),
             label: allowedNetwork.name,
           }))}

--- a/src/components/SafeInformation.tsx
+++ b/src/components/SafeInformation.tsx
@@ -1,11 +1,12 @@
-import { useContext, useState } from "react";
-import { SafeInformationContext } from "../app/ViewSafe";
+import { useState } from "react";
 import { Button, Card, Text, View } from "reshaped";
 import { allowedNetworks } from "../chains";
 import { InfoBox } from "../components/InfoBox";
 import { Address } from "viem";
 import { AddressView } from "../components/AddressView";
 import { OwnerAction, SetOwnerModal } from "../components/SetOwnerModal";
+import { useOutletContext } from "react-router-dom";
+import { SafeContext } from "./Contexts";
 
 const SafeInformationItem = ({
   title,
@@ -31,9 +32,8 @@ export const SafeInformation = ({
 }) => {
   const [ownerAction, setOwnerAction] = useState<OwnerAction>();
 
-  const safeInformation = useContext(SafeInformationContext);
+  const { safeInformation } = useOutletContext<SafeContext>();
 
-  if (!safeInformation) return <div></div>;
   return (
     <div>
       {ownerAction && (

--- a/src/components/SetOwnerModal.tsx
+++ b/src/components/SetOwnerModal.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useContext } from "react";
+import { SyntheticEvent } from "react";
 import { Button, Modal, Text, View, useToast } from "reshaped";
 import { AddressView } from "./AddressView";
 import { Address } from "viem";
@@ -6,8 +6,8 @@ import { Field, Form, Formik } from "formik";
 import { GenericField } from "./GenericField";
 import { yupAddress } from "../utils/validators";
 import { number, object } from "yup";
-import { useSearchParams } from "react-router-dom";
-import { SafeInformationContext } from "../app/ViewSafe";
+import { useOutletContext, useSearchParams } from "react-router-dom";
+import { SafeContext } from "./Contexts";
 
 export type OwnerAction =
   | undefined
@@ -41,7 +41,7 @@ const ButtonPanel = ({
 );
 
 const AddOwnerModalContent = ({ onClose }: { onClose: () => void }) => {
-  const safeInformation = useContext(SafeInformationContext);
+  const { safeInformation } = useOutletContext<SafeContext>();
   const toast = useToast();
   const [, setSearchParams] = useSearchParams();
   return (
@@ -103,7 +103,7 @@ const RemoveOwnerModalContent = ({
   target: string;
 }) => {
   const [_, setParams] = useSearchParams();
-  const safeInformation = useContext(SafeInformationContext);
+  const { safeInformation } = useOutletContext<SafeContext>();
 
   const onSubmitClick = async ({ threshold }: any) => {
     const removeOwnerTx = await safeInformation?.safeSdk.createRemoveOwnerTx({


### PR DESCRIPTION
Fix bug where network dropdown or network id in the url doesn't always match the current network connected to.

This PR does it by:
* switching to the more react router native useOutletContext for passing context to children.
* having the network switcher change to navigate to a new url
* the current network id is always pulled from the current url, and it it mismatches, prompts metamask to switch to the proper url