### PR TITLE
Improvements to #26 - replace context for explicit props, remove duplicate state,  fix creation of a new proposal

### DIFF
--- a/src/app/NewSafeProposal.tsx
+++ b/src/app/NewSafeProposal.tsx
@@ -20,7 +20,7 @@ import {
 } from "../utils/etherFormatting";
 import { useOutletContext } from "react-router-dom";
 import { NetworkContext, SafeContext } from "../components/Contexts";
-import { useUpdateProposal } from "../hooks/useUpdateProposalViaQuery";
+import { useUpdateProposalInQuery } from "../hooks/useUpdateProposalViaQuery";
 
 const FormActionItem = ({
   name,
@@ -383,19 +383,16 @@ const EditProposal = ({
 };
 
 export const NewSafeProposal = () => {
-  const [proposal, setProposal] = useState<undefined | Proposal>(
-    DEFAULT_PROPOSAL
-  );
   const [isEditing, setIsEditing] = useState(true);
 
-  const proposalFromQuery = useLoadProposalFromQuery();
+  const proposal = useLoadProposalFromQuery();
+  const { addAction, replace } = useUpdateProposalInQuery({ proposal });
 
   useEffect(() => {
-    if (proposalFromQuery) {
-      setProposal(proposalFromQuery);
+    if (proposal) {
       setIsEditing(false);
     }
-  }, [proposalFromQuery]);
+  }, [proposal]);
 
   const handleEditClicked = useCallback(
     (evt: SyntheticEvent) => {
@@ -405,16 +402,11 @@ export const NewSafeProposal = () => {
     [setIsEditing]
   );
 
-  const updateProposal = useUpdateProposal({ proposal });
-
   return (
     <View paddingTop={4} paddingBottom={8} gap={8}>
-      <SafeInformation updateProposal={updateProposal}>
+      <SafeInformation addAction={addAction}>
         {isEditing && (
-          <EditProposal
-            proposal={proposal}
-            setProposal={updateProposal.replace}
-          />
+          <EditProposal proposal={proposal} setProposal={replace} />
         )}
         {!isEditing && proposal && (
           <ViewProposal

--- a/src/app/SafeInformationPage.tsx
+++ b/src/app/SafeInformationPage.tsx
@@ -1,6 +1,7 @@
 import { Button, View } from "reshaped";
 import { SafeInformation } from "../components/SafeInformation";
 import { useNavigate, useParams } from "react-router-dom";
+import { useUpdateProposalInQuery } from "../hooks/useUpdateProposalViaQuery";
 
 export const SafeInformationPage = () => {
   const { networkId, safeAddress } = useParams();
@@ -10,9 +11,11 @@ export const SafeInformationPage = () => {
     navigate(`/safe/${networkId}/${safeAddress}/new`);
   };
 
+  const { addAction } = useUpdateProposalInQuery({ proposal: undefined });
+
   return (
     <View gap={4}>
-      <SafeInformation />
+      <SafeInformation addAction={addAction} />
       <Button onClick={onNewProposalClick}>New Proposal</Button>
     </View>
   );

--- a/src/components/SafeInformation.tsx
+++ b/src/components/SafeInformation.tsx
@@ -7,7 +7,7 @@ import { AddressView } from "../components/AddressView";
 import { OwnerAction, SetOwnerModal } from "../components/SetOwnerModal";
 import { useOutletContext } from "react-router-dom";
 import { SafeContext } from "./Contexts";
-import { UpdateProposal } from "../hooks/useUpdateProposalViaQuery";
+import { AddAction } from "../hooks/useUpdateProposalViaQuery";
 
 const SafeInformationItem = ({
   title,
@@ -28,10 +28,10 @@ const SafeInformationItem = ({
 
 export const SafeInformation = ({
   children,
-  updateProposal,
+  addAction,
 }: {
   children?: React.ReactNode;
-  updateProposal: UpdateProposal;
+  addAction: AddAction;
 }) => {
   const [ownerAction, setOwnerAction] = useState<OwnerAction>();
 
@@ -45,7 +45,7 @@ export const SafeInformation = ({
             setOwnerAction(undefined);
           }}
           action={ownerAction}
-          updatedProposal={updateProposal}
+          addAction={addAction}
         />
       )}
       <Card>

--- a/src/components/SafeInformation.tsx
+++ b/src/components/SafeInformation.tsx
@@ -7,6 +7,7 @@ import { AddressView } from "../components/AddressView";
 import { OwnerAction, SetOwnerModal } from "../components/SetOwnerModal";
 import { useOutletContext } from "react-router-dom";
 import { SafeContext } from "./Contexts";
+import { UpdateProposal } from "../hooks/useUpdateProposalViaQuery";
 
 const SafeInformationItem = ({
   title,
@@ -27,8 +28,10 @@ const SafeInformationItem = ({
 
 export const SafeInformation = ({
   children,
+  updateProposal,
 }: {
   children?: React.ReactNode;
+  updateProposal: UpdateProposal;
 }) => {
   const [ownerAction, setOwnerAction] = useState<OwnerAction>();
 
@@ -42,6 +45,7 @@ export const SafeInformation = ({
             setOwnerAction(undefined);
           }}
           action={ownerAction}
+          updatedProposal={updateProposal}
         />
       )}
       <Card>

--- a/src/components/SetOwnerModal.tsx
+++ b/src/components/SetOwnerModal.tsx
@@ -8,7 +8,7 @@ import { yupAddress } from "../utils/validators";
 import { number, object } from "yup";
 import { useOutletContext } from "react-router-dom";
 import { SafeContext } from "./Contexts";
-import { UpdateProposal } from "../hooks/useUpdateProposalViaQuery";
+import { AddAction } from "../hooks/useUpdateProposalViaQuery";
 
 export type OwnerAction =
   | undefined
@@ -43,10 +43,10 @@ const ButtonPanel = ({
 
 const AddOwnerModalContent = ({
   onClose,
-  updateProposal: { addAction },
+  addAction,
 }: {
   onClose: () => void;
-  updateProposal: UpdateProposal;
+  addAction: AddAction;
 }) => {
   const { safeInformation } = useOutletContext<SafeContext>();
   const toast = useToast();
@@ -99,11 +99,11 @@ const AddOwnerModalContent = ({
 const RemoveOwnerModalContent = ({
   onClose,
   target,
-  updateProposal: { addAction },
+  addAction,
 }: {
   onClose: () => void;
   target: string;
-  updateProposal: UpdateProposal;
+  addAction: AddAction;
 }) => {
   const { safeInformation } = useOutletContext<SafeContext>();
   const toaster = useToast();
@@ -162,11 +162,11 @@ const RemoveOwnerModalContent = ({
 export const SetOwnerModal = ({
   action,
   onClose,
-  updatedProposal,
+  addAction,
 }: {
   action: OwnerAction;
   onClose: () => void;
-  updatedProposal: UpdateProposal;
+  addAction: AddAction;
 }) => {
   return (
     <Modal active={!!action} onClose={onClose}>
@@ -174,14 +174,11 @@ export const SetOwnerModal = ({
         <RemoveOwnerModalContent
           onClose={onClose}
           target={action.address}
-          updateProposal={updatedProposal}
+          addAction={addAction}
         />
       )}
       {action?.type === "add" && (
-        <AddOwnerModalContent
-          onClose={onClose}
-          updateProposal={updatedProposal}
-        />
+        <AddOwnerModalContent onClose={onClose} addAction={addAction} />
       )}
     </Modal>
   );

--- a/src/components/SetOwnerModal.tsx
+++ b/src/components/SetOwnerModal.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useContext } from "react";
+import { SyntheticEvent } from "react";
 import { Button, Modal, Text, View, useToast } from "reshaped";
 import { AddressView } from "./AddressView";
 import { Address } from "viem";
@@ -8,8 +8,7 @@ import { yupAddress } from "../utils/validators";
 import { number, object } from "yup";
 import { useOutletContext } from "react-router-dom";
 import { SafeContext } from "./Contexts";
-import { ProposalContext } from "../app/NewSafeProposal";
-import { useUpdateProposalViaQuery } from "../hooks/useUpdateProposalViaQuery";
+import { UpdateProposal } from "../hooks/useUpdateProposalViaQuery";
 
 export type OwnerAction =
   | undefined
@@ -42,11 +41,15 @@ const ButtonPanel = ({
   </View>
 );
 
-const AddOwnerModalContent = ({ onClose }: { onClose: () => void }) => {
+const AddOwnerModalContent = ({
+  onClose,
+  updateProposal: { addAction },
+}: {
+  onClose: () => void;
+  updateProposal: UpdateProposal;
+}) => {
   const { safeInformation } = useOutletContext<SafeContext>();
   const toast = useToast();
-  const updateProposalQuery = useUpdateProposalViaQuery();
-  const currentProposal = useContext(ProposalContext);
 
   return (
     <Formik
@@ -62,7 +65,7 @@ const AddOwnerModalContent = ({ onClose }: { onClose: () => void }) => {
             ownerAddress: address,
             threshold: threshold,
           });
-          updateProposalQuery({
+          addAction({
             data: addOwnerTx.data.data,
             value: "0",
             to: safeInformation.address,
@@ -96,12 +99,13 @@ const AddOwnerModalContent = ({ onClose }: { onClose: () => void }) => {
 const RemoveOwnerModalContent = ({
   onClose,
   target,
+  updateProposal: { addAction },
 }: {
   onClose: () => void;
   target: string;
+  updateProposal: UpdateProposal;
 }) => {
   const { safeInformation } = useOutletContext<SafeContext>();
-  const updateProposalViaQuery = useUpdateProposalViaQuery();
   const toaster = useToast();
 
   const onSubmitClick = async ({ threshold }: any) => {
@@ -110,13 +114,13 @@ const RemoveOwnerModalContent = ({
         {
           ownerAddress: target,
           threshold: threshold,
-        },
+        }
       );
       if (!removeOwnerTx || !safeInformation) {
         return;
       }
 
-      updateProposalViaQuery({
+      addAction({
         data: removeOwnerTx.data.data,
         value: "0",
         to: safeInformation.address,
@@ -158,16 +162,27 @@ const RemoveOwnerModalContent = ({
 export const SetOwnerModal = ({
   action,
   onClose,
+  updatedProposal,
 }: {
   action: OwnerAction;
   onClose: () => void;
+  updatedProposal: UpdateProposal;
 }) => {
   return (
     <Modal active={!!action} onClose={onClose}>
       {action?.type === "remove" && (
-        <RemoveOwnerModalContent onClose={onClose} target={action.address} />
+        <RemoveOwnerModalContent
+          onClose={onClose}
+          target={action.address}
+          updateProposal={updatedProposal}
+        />
       )}
-      {action?.type === "add" && <AddOwnerModalContent onClose={onClose} />}
+      {action?.type === "add" && (
+        <AddOwnerModalContent
+          onClose={onClose}
+          updateProposal={updatedProposal}
+        />
+      )}
     </Modal>
   );
 };

--- a/src/hooks/useLoadProposalFromQuery.ts
+++ b/src/hooks/useLoadProposalFromQuery.ts
@@ -38,7 +38,12 @@ export const useLoadProposalFromQuery = () => {
 
       console.log({ actions, txt: "setting proposal" });
 
-      setProposal({ actions, ...(nonce ? { [queryKeys.nonce]: nonce } : {}) });
+      const proposal: Proposal = {
+        actions,
+        ...(nonce ? { nonce: parseInt(nonce) } : {}),
+      };
+
+      setProposal(proposal);
     }
   }, [params, setProposal]);
 

--- a/src/hooks/useSetParamsFromQuery.ts
+++ b/src/hooks/useSetParamsFromQuery.ts
@@ -1,17 +1,25 @@
 import { useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { Proposal } from "../schemas/proposal";
 import { queryKeys } from "./useLoadProposalFromQuery";
 
 export const useRedirectToProposalWithNewParams = () => {
   const [, setParams] = useSearchParams();
+  const { networkId, safeAddress } = useParams();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
 
   return useCallback(
     (proposal: Proposal) => {
       if (!proposal.actions?.length) {
         return;
       }
-      setParams({
+      const params = {
         [queryKeys.targets]: proposal
           .actions!.map((action) => action.to)
           .join("|"),
@@ -26,8 +34,18 @@ export const useRedirectToProposalWithNewParams = () => {
               [queryKeys.nonce]: proposal.nonce.toString(),
             }
           : {}),
-      });
+      };
+      // if we are not in a new safe proposal, we need to redirect to new safe proposal
+      // so that it shows up in the url, and renders correctly
+      if (!pathname.includes("new")) {
+        const newPath = `/safe/${networkId}/${safeAddress}/new`;
+
+        navigate(newPath, {
+          replace: true,
+        });
+      }
+      setParams(params);
     },
-    [setParams]
+    [setParams, networkId, safeAddress, pathname, navigate]
   );
 };

--- a/src/hooks/useSetParamsFromQuery.ts
+++ b/src/hooks/useSetParamsFromQuery.ts
@@ -4,7 +4,7 @@ import { Proposal } from "../schemas/proposal";
 import { queryKeys } from "./useLoadProposalFromQuery";
 
 export const useRedirectToProposalWithNewParams = () => {
-  const [_, setParams] = useSearchParams();
+  const [, setParams] = useSearchParams();
 
   return useCallback(
     (proposal: Proposal) => {
@@ -12,9 +12,15 @@ export const useRedirectToProposalWithNewParams = () => {
         return;
       }
       setParams({
-        [queryKeys.targets]: proposal.actions!.map((action) => action.to).join("|"),
-        [queryKeys.calldatas]: proposal.actions!.map((action) => action.data).join("|"),
-        [queryKeys.values]: proposal.actions!.map((action) => action.value).join("|"),
+        [queryKeys.targets]: proposal
+          .actions!.map((action) => action.to)
+          .join("|"),
+        [queryKeys.calldatas]: proposal
+          .actions!.map((action) => action.data)
+          .join("|"),
+        [queryKeys.values]: proposal
+          .actions!.map((action) => action.value)
+          .join("|"),
         ...(proposal.nonce
           ? {
               [queryKeys.nonce]: proposal.nonce.toString(),
@@ -22,6 +28,6 @@ export const useRedirectToProposalWithNewParams = () => {
           : {}),
       });
     },
-    [setParams],
+    [setParams]
   );
 };

--- a/src/hooks/useUpdateProposalViaQuery.ts
+++ b/src/hooks/useUpdateProposalViaQuery.ts
@@ -1,19 +1,30 @@
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 import { Proposal } from "../schemas/proposal";
-import { ProposalContext } from "../app/NewSafeProposal";
 import { useRedirectToProposalWithNewParams } from "./useSetParamsFromQuery";
 
-export const useUpdateProposalViaQuery = () => {
+export type UpdateProposal = {
+  addAction: (newAction: NonNullable<Proposal["actions"]>[0]) => void;
+  replace: (proposal: Proposal) => void;
+};
+export const useUpdateProposal = ({
+  proposal,
+}: {
+  proposal: Proposal | undefined;
+}): UpdateProposal => {
   const setParams = useRedirectToProposalWithNewParams();
-  const proposal = useContext(ProposalContext);
 
-  return useCallback(
+  const addAction = useCallback(
     (newAction: NonNullable<Proposal["actions"]>[0]) => {
       setParams({
         actions: [...(proposal?.actions || []), newAction],
         nonce: proposal?.nonce,
       });
     },
-    [proposal, setParams],
+    [proposal, setParams]
   );
+
+  return {
+    addAction,
+    replace: setParams,
+  };
 };

--- a/src/hooks/useUpdateProposalViaQuery.ts
+++ b/src/hooks/useUpdateProposalViaQuery.ts
@@ -2,11 +2,15 @@ import { useCallback } from "react";
 import { Proposal } from "../schemas/proposal";
 import { useRedirectToProposalWithNewParams } from "./useSetParamsFromQuery";
 
+export type AddAction = (
+  newAction: NonNullable<Proposal["actions"]>[0]
+) => void;
+
 export type UpdateProposal = {
-  addAction: (newAction: NonNullable<Proposal["actions"]>[0]) => void;
+  addAction: AddAction;
   replace: (proposal: Proposal) => void;
 };
-export const useUpdateProposal = ({
+export const useUpdateProposalInQuery = ({
   proposal,
 }: {
   proposal: Proposal | undefined;


### PR DESCRIPTION
* Better naming around provider updating/namely: `addAction` and `replaceProposal`
* Replace ProviderContext with explicit prop passing; remove duplicate `proposal` state and just have query string be source of truth
* Fix some type failing issues
* When there is no current proposal, and a user is to be added/removed from the safe, redirect to a `new` url so that the url can be properly shared